### PR TITLE
[Incubator/Cassandra] Fix missing selector

### DIFF
--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -13,6 +13,10 @@ spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}
+  selector:
+    matchLabels:
+      app: {{ template "cassandra.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch fixes issue that spec.selector was missing from cassandra statefulset.yml


